### PR TITLE
fix: neon 0.1.21 removed Variant::Integer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 [dependencies]
 serde = "1.*"
 error-chain = "0.11.*"
-neon = "0.1.*"
+neon = ">=0.1.21"
 cast = "0.2.*"
 
 [dev-dependencies]

--- a/src/de.rs
+++ b/src/de.rs
@@ -61,7 +61,6 @@ impl<'de, 'a, S: 'de + Scope<'de>> serde::de::Deserializer<'de> for &'a mut Dese
             Variant::Null(_) => visitor.visit_unit(),
             Variant::Boolean(val) => visitor.visit_bool(val.value()),
             Variant::String(val) => visitor.visit_string(val.value()),
-            Variant::Integer(val) => visitor.visit_i64(val.value()), // TODO is u32 or i32,
             Variant::Number(val) => visitor.visit_f64(val.value()),
             Variant::Array(_) => self.deserialize_seq(visitor),
             Variant::Object(_) => self.deserialize_map(visitor),


### PR DESCRIPTION
Hi! It seems like neon 0.1.21 no longer has a `Variant::Integer` option so neon-serde breaks when building against it.