### PR TITLE
Skip deserializing unused values

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -143,11 +143,18 @@ impl<'x, 'd, 'a, 'j, S: Scope<'j>> serde::de::Deserializer<'x> for &'d mut Deser
         visitor.visit_byte_buf(copy)
     }
 
+    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'x>,
+    {
+        visitor.visit_unit()
+    }
+
     forward_to_deserialize_any! {
        <V: Visitor<'x>>
         bool i8 i16 i32 i64 u8 u16 u32 u64 f32 f64 char str string
         unit unit_struct seq tuple tuple_struct map struct identifier
-        newtype_struct ignored_any
+        newtype_struct
     }
 }
 

--- a/test/__tests__/get_values.js
+++ b/test/__tests__/get_values.js
@@ -62,7 +62,7 @@ describe('all values ok', () => {
     });
 
     test('expect_obj', () => {
-        native.expect_obj({
+        const o = {
             a: 1,
             b: [1, 2],
             c: "abc",
@@ -77,7 +77,11 @@ describe('all values ok', () => {
             l: "jkl",
             m: [0,1,2,3,4],
             o: {Value: ['z', 'y', 'x']}
-        });
+        };
+
+        o.self = o;
+
+        native.expect_obj(o);
     });
 
     test('expect_num_array', () => {


### PR DESCRIPTION
This should optimize parsing sparse objects by preventing recursion if the value is thrown away. It also partially resolves https://github.com/GabrielCastro/neon-serde/issues/15 for circular references that are not in the model.

For example, attempting to deserialize even a single field from the http `request` object will cause a segfault from the circular references even `client`, `socket`, and `connection` (the objects that contain circular references) are omitted.

The full fix for circular references will require some bookkeeping on raw handles in the depth first walk. I'm not sure this is worth it because it would require a rust object that allows for cycles and a source object that also has them.