### PR TITLE
Neon 0.2 compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "readme.md"
 serde = "1.*"
 error-chain = "0.11.*"
 neon = "0.2.*"
-neon-runtime = "0.2.x"
+neon-runtime = "0.2.*"
 cast = "0.2.*"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ readme = "readme.md"
 [dependencies]
 serde = "1.*"
 error-chain = "0.11.*"
-neon = "0.1.*"
+neon = "0.2.*"
+neon-runtime = "0.2.x"
 cast = "0.2.*"
 
 [dev-dependencies]

--- a/readme.md
+++ b/readme.md
@@ -70,8 +70,7 @@ extern crate neon;
 #[macro_use]
 extern crate serde_derive;
 
-use neon::js::{JsValue, JsUndefined};
-use neon::vm::{Call, JsResult};
+use neon::prelude::*;
 
 #[derive(Serialize, Debug, Deserialize)]
 struct AnObject {
@@ -80,30 +79,25 @@ struct AnObject {
     c: String,
 }
 
-fn deserialize_something(call: Call) -> JsResult<JsValue> {
-    let scope = call.scope;
-    let arg0 = call.arguments
-         .require(scope, 0)?
-         .check::<JsValue>()?;
+fn deserialize_something(mut cx: FunctionContext) -> JsResult<JsValue> {
+    let arg0 = cx.argument::<JsValue>(0)?;
 
-    let arg0_value :AnObject = neon_serde::from_value(scope, arg0)?;
+    let arg0_value :AnObject = neon_serde::from_value(&mut cx, arg0)?;
     println!("{:?}", arg0_value);
 
     Ok(JsUndefined::new().upcast())
 }
 
-fn serialize_something(call: Call) -> JsResult<JsValue> {
-    let scope = call.scope;
+fn serialize_something(mut cx: FunctionContext) -> JsResult<JsValue> {
     let value = AnObject {
         a: 1,
         b: vec![2f64, 3f64, 4f64],
         c: "a string".into()
     };
 
-    let js_value = neon_serde::to_value(scope, &value)?;
+    let js_value = neon_serde::to_value(&mut cx, &value)?;
     Ok(js_value)
 }
-
 ```
 
 ## Limitations

--- a/src/de.rs
+++ b/src/de.rs
@@ -54,7 +54,12 @@ impl<'x, 'd, 'a, 'j> serde::de::Deserializer<'x> for &'d mut Deserializer<'a, 'j
         } else if let Ok(val) = self.input.downcast::<JsString>() {
             visitor.visit_string(val.value())
         } else if let Ok(val) = self.input.downcast::<JsNumber>() {
-            visitor.visit_f64(val.value())
+            let v = val.value();
+            if v.trunc() == v {
+                visitor.visit_i64(v as i64)
+            } else {
+                visitor.visit_f64(v)
+            }
         } else if let Ok(val) = self.input.downcast::<JsArray>() {
             let mut deserializer = JsArrayAccess::new(self.cx, val);
             visitor.visit_seq(&mut deserializer)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,8 +35,7 @@
 //! #[macro_use]
 //! extern crate serde_derive;
 //!
-//! use neon::js::{JsValue, JsUndefined};
-//! use neon::vm::{Call, JsResult};
+//! use neon::prelude::*;
 //!
 //! #[derive(Serialize, Debug, Deserialize)]
 //! struct AnObject {
@@ -45,27 +44,23 @@
 //!     c: String,
 //! }
 //!
-//! fn deserialize_something(call: Call) -> JsResult<JsValue> {
-//!     let scope = call.scope;
-//!     let arg0 = call.arguments
-//!          .require(scope, 0)?
-//!          .check::<JsValue>()?;
+//! fn deserialize_something(mut cx: FunctionContext) -> JsResult<JsValue> {
+//!     let arg0 = cx.argument::<JsValue>(0)?;
 //!
-//!     let arg0_value :AnObject = neon_serde::from_value(scope, arg0)?;
+//!     let arg0_value :AnObject = neon_serde::from_value(&mut cx, arg0)?;
 //!     println!("{:?}", arg0_value);
 //!
 //!     Ok(JsUndefined::new().upcast())
 //! }
 //!
-//! fn serialize_something(call: Call) -> JsResult<JsValue> {
-//!     let scope = call.scope;
+//! fn serialize_something(mut cx: FunctionContext) -> JsResult<JsValue> {
 //!     let value = AnObject {
 //!         a: 1,
 //!         b: vec![2f64, 3f64, 4f64],
 //!         c: "a string".into()
 //!     };
 //!
-//!     let js_value = neon_serde::to_value(scope, &value)?;
+//!     let js_value = neon_serde::to_value(&mut cx, &value)?;
 //!     Ok(js_value)
 //! }
 //!
@@ -94,20 +89,17 @@ pub use ser::to_value;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use neon::js::JsValue;
-    use neon::mem::Handle;
-    use neon::vm::{Call, JsResult};
+    use neon::prelude::*;
 
     #[test]
     fn test_it_compiles() {
-        fn check<'j>(call: Call<'j>) -> JsResult<'j, JsValue> {
-            let scope = call.scope;
+        fn check<'j>(mut cx: FunctionContext<'j>) -> JsResult<'j, JsValue> {
             let result: () = {
-                let arg: Handle<'j, JsValue> = call.arguments.require(scope, 0)?;
-                let () = from_value(scope, arg)?;
+                let arg: Handle<'j, JsValue> = cx.argument::<JsValue>(0)?;
+                let () = from_value(&mut cx, arg)?;
                 ()
             };
-            let result: Handle<'j, JsValue> = to_value(scope, &result)?;
+            let result: Handle<'j, JsValue> = to_value(&mut cx, &result)?;
             Ok(result)
         }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -11,22 +11,20 @@ macro_rules! export {
             fn $name($( $arg: $atype ),*) -> $ret $code
         )*
 
-        register_module!(m, {
+        register_module!(mut m, {
             $(
-                m.export(stringify!($name), |call| {
-                    let scope = call.scope;
-
+                m.export_function(stringify!($name), |mut cx| {
                     // Can be done away with a fancier macro
                     let mut _arg_index = 0;
 
                     $(
-                        let $arg = call.arguments.require(scope, _arg_index)?;
-                        let $arg: $atype = $crate::from_value(scope, $arg)?;
+                        let $arg = cx.argument::<neon::types::JsValue>(_arg_index)?;
+                        let $arg: $atype = $crate::from_value(&mut cx, $arg)?;
                         _arg_index += 1;
                     )*
 
                     let result = $name($( $arg ),*);
-                    let handle = $crate::to_value(scope, &result)?;
+                    let handle = $crate::to_value(&mut cx, &result)?;
                     Ok(handle)
                 })?;
             )*

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -6,11 +6,7 @@ use cast;
 use errors::Error;
 use errors::ErrorKind;
 use errors::Result as LibResult;
-use neon::js;
-use neon::js::Object;
-use neon::mem::Handle;
-use neon::scope::Scope;
-use neon::vm::Lock;
+use neon::prelude::*;
 use serde::ser::{self, Serialize};
 use std::marker::PhantomData;
 
@@ -22,13 +18,12 @@ use std::marker::PhantomData;
 /// * `StringTooLong` if the string exceeds v8's max string size
 ///
 #[inline]
-pub fn to_value<'j, S, V>(scope: &mut S, value: &V) -> LibResult<Handle<'j, js::JsValue>>
+pub fn to_value<'j, V>(cx: &mut FunctionContext<'j>, value: &V) -> LibResult<Handle<'j, JsValue>>
 where
-    S: Scope<'j>,
     V: Serialize + ?Sized,
 {
     let serializer = Serializer {
-        scope,
+        cx,
         ph: PhantomData,
     };
     let serialized_value = value.serialize(serializer)?;
@@ -36,156 +31,142 @@ where
 }
 
 #[doc(hidden)]
-pub struct Serializer<'a, 'j, S: 'a>
-where
-    S: Scope<'j>,
+pub struct Serializer<'a, 'j: 'a>
 {
-    scope: &'a mut S,
+    cx: &'a mut FunctionContext<'j>,
     ph: PhantomData<&'j ()>,
 }
 
 #[doc(hidden)]
-pub struct ArraySerializer<'a, 'j, S: 'a>
-where
-    S: Scope<'j>,
+pub struct ArraySerializer<'a, 'j: 'a>
 {
-    scope: &'a mut S,
-    array: Handle<'j, js::JsArray>,
+    cx: &'a mut FunctionContext<'j>,
+    array: Handle<'j, JsArray>,
 }
 
 #[doc(hidden)]
-pub struct TupleVariantSerializer<'a, 'j, S: 'a>
-where
-    S: Scope<'j>,
+pub struct TupleVariantSerializer<'a, 'j: 'a>
 {
-    outter_object: Handle<'j, js::JsObject>,
-    inner: ArraySerializer<'a, 'j, S>,
+    outter_object: Handle<'j, JsObject>,
+    inner: ArraySerializer<'a, 'j>,
 }
 
 #[doc(hidden)]
-pub struct MapSerializer<'a, 'j, S: 'a>
-where
-    S: Scope<'j>,
+pub struct MapSerializer<'a, 'j: 'a>
 {
-    scope: &'a mut S,
-    object: Handle<'j, js::JsObject>,
-    key_holder: Handle<'j, js::JsObject>,
+    cx: &'a mut FunctionContext<'j>,
+    object: Handle<'j, JsObject>,
+    key_holder: Handle<'j, JsObject>,
 }
 
 #[doc(hidden)]
-pub struct StructSerializer<'a, 'j, S: 'a>
-where
-    S: Scope<'j>,
+pub struct StructSerializer<'a, 'j: 'a>
 {
-    scope: &'a mut S,
-    object: Handle<'j, js::JsObject>,
+    cx: &'a mut FunctionContext<'j>,
+    object: Handle<'j, JsObject>,
 }
 
 #[doc(hidden)]
-pub struct StructVariantSerializer<'a, 'j, S: 'a>
-where
-    S: Scope<'j>,
+pub struct StructVariantSerializer<'a, 'j: 'a>
 {
-    outer_object: Handle<'j, js::JsObject>,
-    inner: StructSerializer<'a, 'j, S>,
+    outer_object: Handle<'j, JsObject>,
+    inner: StructSerializer<'a, 'j>,
 }
 
 #[doc(hidden)]
-impl<'a, 'j, S> ser::Serializer for Serializer<'a, 'j, S>
-where
-    S: Scope<'j>,
+impl<'a, 'j> ser::Serializer for Serializer<'a, 'j>
 {
-    type Ok = Handle<'j, js::JsValue>;
+    type Ok = Handle<'j, JsValue>;
     type Error = Error;
 
-    type SerializeSeq = ArraySerializer<'a, 'j, S>;
-    type SerializeTuple = ArraySerializer<'a, 'j, S>;
-    type SerializeTupleStruct = ArraySerializer<'a, 'j, S>;
-    type SerializeTupleVariant = TupleVariantSerializer<'a, 'j, S>;
-    type SerializeMap = MapSerializer<'a, 'j, S>;
-    type SerializeStruct = StructSerializer<'a, 'j, S>;
-    type SerializeStructVariant = StructVariantSerializer<'a, 'j, S>;
+    type SerializeSeq = ArraySerializer<'a, 'j>;
+    type SerializeTuple = ArraySerializer<'a, 'j>;
+    type SerializeTupleStruct = ArraySerializer<'a, 'j>;
+    type SerializeTupleVariant = TupleVariantSerializer<'a, 'j>;
+    type SerializeMap = MapSerializer<'a, 'j>;
+    type SerializeStruct = StructSerializer<'a, 'j>;
+    type SerializeStructVariant = StructVariantSerializer<'a, 'j>;
 
     #[inline]
     fn serialize_bool(self, v: bool) -> Result<Self::Ok, Self::Error> {
-        Ok(js::JsBoolean::new(self.scope, v).upcast())
+        Ok(JsBoolean::new(self.cx, v).upcast())
     }
 
     #[inline]
     fn serialize_i8(self, v: i8) -> Result<Self::Ok, Self::Error> {
-        Ok(js::JsNumber::new(self.scope, cast::f64(v)).upcast())
+        Ok(JsNumber::new(self.cx, cast::f64(v)).upcast())
     }
 
     #[inline]
     fn serialize_i16(self, v: i16) -> Result<Self::Ok, Self::Error> {
-        Ok(js::JsNumber::new(self.scope, cast::f64(v)).upcast())
+        Ok(JsNumber::new(self.cx, cast::f64(v)).upcast())
     }
 
     #[inline]
     fn serialize_i32(self, v: i32) -> Result<Self::Ok, Self::Error> {
-        Ok(js::JsNumber::new(self.scope, cast::f64(v)).upcast())
+        Ok(JsNumber::new(self.cx, cast::f64(v)).upcast())
     }
 
     #[inline]
     fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
-        Ok(js::JsNumber::new(self.scope, cast::f64(v)).upcast())
+        Ok(JsNumber::new(self.cx, cast::f64(v)).upcast())
     }
 
     #[inline]
     fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
-        Ok(js::JsNumber::new(self.scope, cast::f64(v)).upcast())
+        Ok(JsNumber::new(self.cx, cast::f64(v)).upcast())
     }
 
     #[inline]
     fn serialize_u16(self, v: u16) -> Result<Self::Ok, Self::Error> {
-        Ok(js::JsNumber::new(self.scope, cast::f64(v)).upcast())
+        Ok(JsNumber::new(self.cx, cast::f64(v)).upcast())
     }
 
     #[inline]
     fn serialize_u32(self, v: u32) -> Result<Self::Ok, Self::Error> {
-        Ok(js::JsNumber::new(self.scope, cast::f64(v)).upcast())
+        Ok(JsNumber::new(self.cx, cast::f64(v)).upcast())
     }
 
     #[inline]
     fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
-        Ok(js::JsNumber::new(self.scope, cast::f64(v)).upcast())
+        Ok(JsNumber::new(self.cx, cast::f64(v)).upcast())
     }
 
     #[inline]
     fn serialize_f32(self, v: f32) -> Result<Self::Ok, Self::Error> {
-        Ok(js::JsNumber::new(self.scope, cast::f64(v)).upcast())
+        Ok(JsNumber::new(self.cx, cast::f64(v)).upcast())
     }
 
     #[inline]
     fn serialize_f64(self, v: f64) -> Result<Self::Ok, Self::Error> {
-        Ok(js::JsNumber::new(self.scope, v).upcast())
+        Ok(JsNumber::new(self.cx, v).upcast())
     }
 
     fn serialize_char(self, v: char) -> Result<Self::Ok, Self::Error> {
         let mut b = [0; 4];
         let result = v.encode_utf8(&mut b);
-        let js_str = js::JsString::new(self.scope, result)
-            .ok_or_else(|| ErrorKind::StringTooLongForChar(4))?;
+        let js_str = JsString::try_new(self.cx, result)
+            .map_err(|_| ErrorKind::StringTooLongForChar(4))?;
         Ok(js_str.upcast())
     }
 
     #[inline]
     fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
         let len = v.len();
-        let js_str = js::JsString::new(self.scope, v).ok_or_else(|| ErrorKind::StringTooLong(len))?;
+        let js_str = JsString::try_new(self.cx, v).map_err(|_| ErrorKind::StringTooLong(len))?;
         Ok(js_str.upcast())
     }
 
     #[inline]
     fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
-        let mut buff = js::binary::JsBuffer::new(self.scope, cast::u32(v.len())?)?;
-        buff.grab(|mut buff| buff.as_mut_slice().clone_from_slice(v));
+        let mut buff = JsBuffer::new(self.cx, cast::u32(v.len())?)?;
+        self.cx.borrow_mut(&mut buff, |buff| buff.as_mut_slice().clone_from_slice(v));
         Ok(buff.upcast())
     }
 
     #[inline]
     fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
-        Ok(js::JsNull::new().upcast())
+        Ok(JsNull::new().upcast())
     }
 
     #[inline]
@@ -198,12 +179,12 @@ where
 
     #[inline]
     fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
-        Ok(js::JsNull::new().upcast())
+        Ok(JsNull::new().upcast())
     }
 
     #[inline]
     fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
-        Ok(js::JsNull::new().upcast())
+        Ok(JsNull::new().upcast())
     }
 
     #[inline]
@@ -239,21 +220,21 @@ where
     where
         T: Serialize,
     {
-        let obj = js::JsObject::new(&mut *self.scope);
-        let value_js = to_value(self.scope, value)?;
-        obj.set(variant, value_js)?;
+        let obj = JsObject::new(&mut *self.cx);
+        let value_js = to_value(self.cx, value)?;
+        obj.set(self.cx, variant, value_js)?;
 
         Ok(obj.upcast())
     }
 
     #[inline]
     fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
-        Ok(ArraySerializer::new(self.scope))
+        Ok(ArraySerializer::new(self.cx))
     }
 
     #[inline]
     fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
-        Ok(ArraySerializer::new(self.scope))
+        Ok(ArraySerializer::new(self.cx))
     }
 
     #[inline]
@@ -262,7 +243,7 @@ where
         _name: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleStruct, Self::Error> {
-        Ok(ArraySerializer::new(self.scope))
+        Ok(ArraySerializer::new(self.cx))
     }
 
     #[inline]
@@ -273,12 +254,12 @@ where
         variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleVariant, Self::Error> {
-        TupleVariantSerializer::new(self.scope, variant)
+        TupleVariantSerializer::new(self.cx, variant)
     }
 
     #[inline]
     fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
-        Ok(MapSerializer::new(self.scope))
+        Ok(MapSerializer::new(self.cx))
     }
 
     #[inline]
@@ -287,7 +268,7 @@ where
         _name: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStruct, Self::Error> {
-        Ok(StructSerializer::new(self.scope))
+        Ok(StructSerializer::new(self.cx))
     }
 
     #[inline]
@@ -298,39 +279,35 @@ where
         variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStructVariant, Self::Error> {
-        StructVariantSerializer::new(self.scope, variant)
+        StructVariantSerializer::new(self.cx, variant)
     }
 }
 
 #[doc(hidden)]
-impl<'a, 'j, S> ArraySerializer<'a, 'j, S>
-where
-    S: Scope<'j>,
+impl<'a, 'j> ArraySerializer<'a, 'j>
 {
     #[inline]
-    fn new(scope: &'a mut S) -> Self {
-        let array = js::JsArray::new(scope, 0);
-        ArraySerializer { scope, array }
+    fn new(cx: &'a mut FunctionContext<'j>) -> Self {
+        let array = JsArray::new(cx, 0);
+        ArraySerializer { cx, array }
     }
 }
 
 #[doc(hidden)]
-impl<'a, 'j, S> ser::SerializeSeq for ArraySerializer<'a, 'j, S>
-where
-    S: Scope<'j>,
+impl<'a, 'j> ser::SerializeSeq for ArraySerializer<'a, 'j>
 {
-    type Ok = Handle<'j, js::JsValue>;
+    type Ok = Handle<'j, JsValue>;
     type Error = Error;
 
     fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
     where
         T: Serialize,
     {
-        let value = to_value(self.scope, value)?;
+        let value = to_value(self.cx, value)?;
 
-        let arr: Handle<'j, js::JsArray> = self.array;
+        let arr: Handle<'j, JsArray> = self.array;
         let len = arr.len();
-        arr.set(len, value)?;
+        arr.set(self.cx, len, value)?;
         Ok(())
     }
 
@@ -340,11 +317,9 @@ where
     }
 }
 
-impl<'a, 'j, S> ser::SerializeTuple for ArraySerializer<'a, 'j, S>
-where
-    S: Scope<'j>,
+impl<'a, 'j> ser::SerializeTuple for ArraySerializer<'a, 'j>
 {
-    type Ok = Handle<'j, js::JsValue>;
+    type Ok = Handle<'j, JsValue>;
     type Error = Error;
 
     #[inline]
@@ -362,11 +337,9 @@ where
 }
 
 #[doc(hidden)]
-impl<'a, 'j, S> ser::SerializeTupleStruct for ArraySerializer<'a, 'j, S>
-where
-    S: Scope<'j>,
+impl<'a, 'j> ser::SerializeTupleStruct for ArraySerializer<'a, 'j>
 {
-    type Ok = Handle<'j, js::JsValue>;
+    type Ok = Handle<'j, JsValue>;
     type Error = Error;
 
     #[inline]
@@ -384,18 +357,16 @@ where
 }
 
 #[doc(hidden)]
-impl<'a, 'j, S> TupleVariantSerializer<'a, 'j, S>
-where
-    S: Scope<'j>,
+impl<'a, 'j> TupleVariantSerializer<'a, 'j>
 {
-    fn new(scope: &'a mut S, key: &'static str) -> LibResult<Self> {
-        let inner_array = js::JsArray::new(scope, 0);
-        let outter_object = js::JsObject::new(scope);
-        outter_object.set(key, inner_array)?;
+    fn new(cx: &'a mut FunctionContext<'j>, key: &'static str) -> LibResult<Self> {
+        let inner_array = JsArray::new(cx, 0);
+        let outter_object = JsObject::new(cx);
+        outter_object.set(cx, key, inner_array)?;
         Ok(TupleVariantSerializer {
             outter_object,
             inner: ArraySerializer {
-                scope,
+                cx,
                 array: inner_array,
             },
         })
@@ -403,11 +374,9 @@ where
 }
 
 #[doc(hidden)]
-impl<'a, 'j, S> ser::SerializeTupleVariant for TupleVariantSerializer<'a, 'j, S>
-where
-    S: Scope<'j>,
+impl<'a, 'j> ser::SerializeTupleVariant for TupleVariantSerializer<'a, 'j>
 {
-    type Ok = Handle<'j, js::JsValue>;
+    type Ok = Handle<'j, JsValue>;
     type Error = Error;
 
     #[inline]
@@ -426,15 +395,13 @@ where
 }
 
 #[doc(hidden)]
-impl<'a, 'j, S> MapSerializer<'a, 'j, S>
-where
-    S: Scope<'j>,
+impl<'a, 'j> MapSerializer<'a, 'j>
 {
-    fn new(scope: &'a mut S) -> Self {
-        let object = js::JsObject::new(scope);
-        let key_holder = js::JsObject::new(scope);
+    fn new(cx: &'a mut FunctionContext<'j>) -> Self {
+        let object = JsObject::new(cx);
+        let key_holder = JsObject::new(cx);
         MapSerializer {
-            scope,
+            cx,
             object,
             key_holder,
         }
@@ -442,19 +409,17 @@ where
 }
 
 #[doc(hidden)]
-impl<'a, 'j, S> ser::SerializeMap for MapSerializer<'a, 'j, S>
-where
-    S: Scope<'j>,
+impl<'a, 'j> ser::SerializeMap for MapSerializer<'a, 'j>
 {
-    type Ok = Handle<'j, js::JsValue>;
+    type Ok = Handle<'j, JsValue>;
     type Error = Error;
 
     fn serialize_key<T: ?Sized>(&mut self, key: &T) -> Result<(), Self::Error>
     where
         T: Serialize,
     {
-        let key = to_value(self.scope, key)?;
-        self.key_holder.set("key", key)?;
+        let key = to_value(self.cx, key)?;
+        self.key_holder.set(self.cx, "key", key)?;
         Ok(())
     }
 
@@ -462,9 +427,9 @@ where
     where
         T: Serialize,
     {
-        let key: Handle<'j, js::JsValue> = self.key_holder.get(&mut *self.scope, "key")?;
-        let value_obj = to_value(self.scope, value)?;
-        self.object.set(key, value_obj)?;
+        let key: Handle<'j, JsValue> = self.key_holder.get(&mut *self.cx, "key")?;
+        let value_obj = to_value(self.cx, value)?;
+        self.object.set(self.cx, key, value_obj)?;
         Ok(())
     }
 
@@ -475,23 +440,19 @@ where
 }
 
 #[doc(hidden)]
-impl<'a, 'j, S> StructSerializer<'a, 'j, S>
-where
-    S: Scope<'j>,
+impl<'a, 'j> StructSerializer<'a, 'j>
 {
     #[inline]
-    fn new(scope: &'a mut S) -> Self {
-        let object = js::JsObject::new(scope);
-        StructSerializer { scope, object }
+    fn new(cx: &'a mut FunctionContext<'j>) -> Self {
+        let object = JsObject::new(cx);
+        StructSerializer { cx, object }
     }
 }
 
 #[doc(hidden)]
-impl<'a, 'j, S> ser::SerializeStruct for StructSerializer<'a, 'j, S>
-where
-    S: Scope<'j>,
+impl<'a, 'j> ser::SerializeStruct for StructSerializer<'a, 'j>
 {
-    type Ok = Handle<'j, js::JsValue>;
+    type Ok = Handle<'j, JsValue>;
     type Error = Error;
 
     #[inline]
@@ -503,8 +464,8 @@ where
     where
         T: Serialize,
     {
-        let value = to_value(self.scope, value)?;
-        self.object.set(key, value)?;
+        let value = to_value(self.cx, value)?;
+        self.object.set(self.cx, key, value)?;
         Ok(())
     }
 
@@ -515,18 +476,16 @@ where
 }
 
 #[doc(hidden)]
-impl<'a, 'j, S> StructVariantSerializer<'a, 'j, S>
-where
-    S: Scope<'j>,
+impl<'a, 'j> StructVariantSerializer<'a, 'j>
 {
-    fn new(scope: &'a mut S, key: &'static str) -> LibResult<Self> {
-        let inner_object = js::JsObject::new(scope);
-        let outter_object = js::JsObject::new(scope);
-        outter_object.set(key, inner_object)?;
+    fn new(cx: &'a mut FunctionContext<'j>, key: &'static str) -> LibResult<Self> {
+        let inner_object = JsObject::new(cx);
+        let outter_object = JsObject::new(cx);
+        outter_object.set(cx, key, inner_object)?;
         Ok(StructVariantSerializer {
             outer_object: outter_object,
             inner: StructSerializer {
-                scope,
+                cx,
                 object: inner_object,
             },
         })
@@ -534,11 +493,9 @@ where
 }
 
 #[doc(hidden)]
-impl<'a, 'j, S> ser::SerializeStructVariant for StructVariantSerializer<'a, 'j, S>
-where
-    S: Scope<'j>,
+impl<'a, 'j> ser::SerializeStructVariant for StructVariantSerializer<'a, 'j>
 {
-    type Ok = Handle<'j, js::JsValue>;
+    type Ok = Handle<'j, JsValue>;
     type Error = Error;
 
     #[inline]

--- a/test/__tests__/get_values.js
+++ b/test/__tests__/get_values.js
@@ -48,7 +48,8 @@ describe('all values ok', () => {
             k: {Struct: { a: 128, b: [9, 8, 7]}},
             l: "jkl",
             m: [0,1,2,3,4],
-            o: {Value: ['z', 'y', 'x']}
+            o: {Value: ['z', 'y', 'x']},
+            p: [1, 2, 3.5]
         });
     });
 
@@ -76,7 +77,8 @@ describe('all values ok', () => {
             k: {Struct: { a: 128, b: [9, 8, 7]}},
             l: "jkl",
             m: [0,1,2,3,4],
-            o: {Value: ['z', 'y', 'x']}
+            o: {Value: ['z', 'y', 'x']},
+            p: [1, 2, 3.5]
         };
 
         o.self = o;
@@ -97,6 +99,33 @@ describe('all values ok', () => {
         if (version >= 57) {
             native.expect_buffer(new Uint8ClampedArray([252, 251, 250]));
         }
+    });
+
+    test('rt_rust_js_rust', () => {
+        const obj = native.make_object();
+        native.expect_obj(obj);
+    });
+
+    test('rt_js_rust_js', () => {
+        const o = {
+            a: 1,
+            b: [1, 2],
+            c: "abc",
+            d: false,
+            e: null,
+            f: null,
+            g: [9, false, "efg"],
+            h: '\uD83E\uDD37',
+            i: "Empty",
+            j: {Tuple: [27, "hij"]},
+            k: {Struct: { a: 128, b: [9, 8, 7]}},
+            l: "jkl",
+            m: [0,1,2,3,4],
+            o: {Value: ['z', 'y', 'x']},
+            p: [1, 2, 3.5]
+        };
+        const o2 = native.roundtrip_object(o);
+        expect(o).toEqual(o2);
     });
 });
 

--- a/test/native/Cargo.toml
+++ b/test/native/Cargo.toml
@@ -11,7 +11,7 @@ name = "test"
 crate-type = ["dylib"]
 
 [build-dependencies]
-neon-build = "0.1.18"
+neon-build = "0.2.0"
 
 [dependencies]
 neon = "0.2.0"

--- a/test/native/Cargo.toml
+++ b/test/native/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["dylib"]
 neon-build = "0.1.18"
 
 [dependencies]
-neon = "0.1.18"
+neon = "0.2.0"
 neon-serde = { path = "../../" }
 serde_derive = "1.0.0"
 serde = "1.0.0"
@@ -22,8 +22,8 @@ serde_bytes = "0.10.1"
 
 [profile.dev]
 codegen-units = 4
-lto = false  
+lto = false
 
 [profile.release]
 codegen-units = 4
-lto = false  
+lto = false

--- a/test/native/src/lib.rs
+++ b/test/native/src/lib.rs
@@ -28,7 +28,7 @@ enum TypeEnum {
     Value(Vec<char>),
 }
 
-#[derive(Serialize, Debug, Deserialize, Eq, PartialEq)]
+#[derive(Serialize, Debug, Deserialize, PartialEq)]
 struct AnObjectTwo {
     a: u32,
     b: Vec<i64>,
@@ -44,6 +44,7 @@ struct AnObjectTwo {
     l: String,
     m: Vec<u8>,
     o: TypeEnum,
+    p: Vec<f64>,
 }
 
 macro_rules! make_test {
@@ -101,6 +102,7 @@ make_test!(make_object, {
         l: "jkl".into(),
         m: vec![0, 1, 2, 3, 4],
         o: TypeEnum::Value(vec!['z', 'y', 'x']),
+        p: vec![1., 2., 3.5],
     };
     value
 });
@@ -147,6 +149,7 @@ make_expect!(
         l: "jkl".into(),
         m: vec![0, 1, 2, 3, 4],
         o: TypeEnum::Value(vec!['z', 'y', 'x']),
+        p: vec![1., 2., 3.5],
     },
     AnObjectTwo
 );
@@ -158,6 +161,14 @@ make_expect!(
     serde_bytes::ByteBuf::from(vec![252u8, 251, 250]),
     serde_bytes::ByteBuf
 );
+
+fn roundtrip_object(mut cx: FunctionContext) -> JsResult<JsValue> {
+    let arg0 = cx.argument::<JsValue>(0)?;
+
+    let de_serialized: AnObjectTwo = neon_serde::from_value(&mut cx, arg0)?;
+    let handle = neon_serde::to_value(&mut cx, &de_serialized)?;
+    Ok(handle)
+}
 
 register_module!(mut m, {
     m.export_function("make_num_77", make_num_77)?;
@@ -173,5 +184,7 @@ register_module!(mut m, {
     m.export_function("expect_obj", expect_obj)?;
     m.export_function("expect_num_array", expect_num_array)?;
     m.export_function("expect_buffer", expect_buffer)?;
+
+    m.export_function("roundtrip_object", roundtrip_object)?;
     Ok(())
 });

--- a/test/package.json
+++ b/test/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "devDependencies": {
     "jest": "^20.0.4",
-    "neon-cli": "^0.1.20"
+    "neon-cli": "^0.2.0"
   },
   "scripts": {
     "build": "neon build",

--- a/test/package.json
+++ b/test/package.json
@@ -10,9 +10,9 @@
     "neon-cli": "^0.2.0"
   },
   "scripts": {
-    "build": "neon build",
-    "build:debug": "neon build --debug",
-    "test": "neon build --debug && jest -i"
+    "build": "neon build --release",
+    "build:debug": "neon build",
+    "test": "neon build && jest -i"
   },
   "jest": {
     "verbose": true,

--- a/test/yarn.lock
+++ b/test/yarn.lock
@@ -347,9 +347,9 @@ builtin-modules@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
-builtins@0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/builtins/-/builtins-0.0.7.tgz#355219cd6cf18dbe7c01cc7fd2dce765cfdc549a"
+builtins@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/builtins/-/builtins-1.0.3.tgz#cb94faeb61c8696451db36534e1422f94f0aee88"
 
 callsites@^2.0.0:
   version "2.0.0"
@@ -374,7 +374,7 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-chalk@^1.1.1, chalk@^1.1.3:
+chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -384,7 +384,7 @@ chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0:
+chalk@^2.0.0, chalk@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
   dependencies:
@@ -859,10 +859,6 @@ iconv-lite@0.4.13:
 iconv-lite@^0.4.17:
   version "0.4.18"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.18.tgz#23d8656b16aae6742ac29732ea8f0336a4789cf2"
-
-in-publish@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/in-publish/-/in-publish-2.0.0.tgz#e20ff5e3a2afc2690320b6dc552682a9c7fadf51"
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -1516,27 +1512,26 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
-neon-cli@^0.1.20:
-  version "0.1.20"
-  resolved "https://registry.yarnpkg.com/neon-cli/-/neon-cli-0.1.20.tgz#a5cbec90ea305c140e5bcb4feda15890fe0edcb8"
+neon-cli@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/neon-cli/-/neon-cli-0.2.0.tgz#cc02148ea7d032f6774e645cc2a9e44e09248b4b"
   dependencies:
-    chalk "^1.1.1"
+    chalk "~2.1.0"
     command-line-args "^4.0.2"
     command-line-commands "^2.0.0"
     command-line-usage "^4.0.0"
     git-config "0.0.7"
     handlebars "^4.0.3"
-    in-publish "^2.0.0"
     inquirer "^3.0.6"
     mkdirp "^0.5.1"
     quickly-copy-file "^1.0.0"
     rimraf "^2.6.1"
-    rsvp "^3.1.0"
+    rsvp "^4.6.1"
     semver "^5.1.0"
     toml "^2.3.0"
     ts-typed-json "^0.2.2"
     validate-npm-package-license "^3.0.1"
-    validate-npm-package-name "^2.2.2"
+    validate-npm-package-name "^3.0.0"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -1866,9 +1861,13 @@ rimraf@^2.6.1:
   dependencies:
     glob "^7.0.5"
 
-rsvp@^3.1.0, rsvp@^3.5.0:
+rsvp@^3.5.0:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
+
+rsvp@^4.6.1:
+  version "4.8.3"
+  resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.3.tgz#25d4b9fdd0f95e216eb5884d9b3767d3fbfbe2cd"
 
 run-async@^2.2.0:
   version "2.3.0"
@@ -2170,11 +2169,11 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
-validate-npm-package-name@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/validate-npm-package-name/-/validate-npm-package-name-2.2.2.tgz#f65695b22f7324442019a3c7fa39a6e7fd299085"
+validate-npm-package-name@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz#5fa912d81eb7d0c74afc140de7317f0ca7df437e"
   dependencies:
-    builtins "0.0.7"
+    builtins "^1.0.3"
 
 verror@1.10.0:
   version "1.10.0"

--- a/test_macro/native/Cargo.toml
+++ b/test_macro/native/Cargo.toml
@@ -11,10 +11,10 @@ name = "test"
 crate-type = ["dylib"]
 
 [build-dependencies]
-neon-build = "0.1.22"
+neon-build = "0.2.0"
 
 [dependencies]
-neon = "0.1.22"
+neon = "0.2.0"
 neon-serde = { path = "../../" }
 serde_derive = "1.0.0"
 serde = "1.0.0"

--- a/test_macro/package.json
+++ b/test_macro/package.json
@@ -7,12 +7,12 @@
   "license": "MIT",
   "devDependencies": {
     "jest": "^20.0.4",
-    "neon-cli": "^0.1.20"
+    "neon-cli": "^0.2.0"
   },
   "scripts": {
-    "build": "neon build",
-    "build:debug": "neon build --debug",
-    "test": "neon build --debug && jest -i"
+    "build": "neon build --release",
+    "build:debug": "neon build",
+    "test": "neon build && jest -i"
   },
   "jest": {
     "verbose": true,


### PR DESCRIPTION
This PR is my first stab at Neon 0.2 support, largely inspired by the [migration guide](https://github.com/neon-bindings/neon/wiki/Neon-0.2-Migration-Guide). It's lots of changes, falling into a few categories.

## Grunt-work changes to the new Neon API shape
- [x] Changed all the instances of `Call` to `FunctionContext` and `Scope` to mutable references to a ~`FunctionContext`~ `C: Context`. ~Also simplified most things that were generic over types `S: Scope`, and changed some lifetime annotations as required by the new API (the lifetime changes could probably use another set of eyes)~ These are now generic over Context instead of generic over Scope, per recommendation of @kjvalencik .
- [x] Changed all the imports, mostly to `use neon::prelude::*;`
- [x] Got rid of uses of `Variant`, which has been removed, in favor of the `if let` pattern recommended in the migration guide
- [x] Got rid of uses of `check`, replacing either with `downcast` or `argument` as appropriate
- [x] Switched to `try_new` on string conversion so as to still catch too-long messages
- [x] Changed to new `borrow` API for buffers
- [x] Changed `export` to `export_function`

## More substantive: JsInteger removal
- [x] Neon 0.2 removes the `JsInteger` type. I first tried just eliminating it and that broke tests that expect to be able to serialize/deserialize integral types, so now I'm checking to see if the number appears integral, and if so casting it to an integer. I'm not sure if that's a good idea or not.
- [x] Added some more-explicit tests for serializing and deserializing floats, including some that look like ints, and added roundtrip tests in both directions.

## More substantive: Error handling
This is the one I'm most nervous about. The error handling logic in this library expects to be able to cast back and forth between the Neon `Throw` type and its own error type. Both directions of casting here were initially broken, and I don't think the fixes I came up with for either are great.
- [x] from `Error` to `Throw`: formerly, casting in this direction involved creating a `JsError` object and then unwrapping its error. However, under the new API there's no way to create a JsError object without a reference to a context, which we don't have within this function. The hack I came up with was to steal code from within Neon used to handle panics; there does appear to be an internal API used in that circumstance that can throw with nothing but a UTF8 string (no context), and that seems to work, but is unsafe (so introduces unsafe code into this library where before there was none), and introduces a new dependency on `neon-runtime`. It doesn't appear that Neon exposes a safe API to do this anymore, though, and I'm not sure if this was an oversight or represents a deliberate API philosophy change, the spirit of which I'm now violating.
- [x] from `Throw` to `Error`: `Throw` no longer implements the standard-library `Error` trait, so error-chain can no longer automatically coerce it. This appears to have been a deliberate change, [per the new Throw docs](https://api.neon-bindings.com/neon/result/struct.throw):
    > Throw deliberately does not implement std::error::Error, because it's generally not a good idea to chain JavaScript exceptions with other kinds of Rust errors, since entering into the throwing state means that the JavaScript engine is unavailable until the exception is handled.

    I hacked around that anyway to preserve the existing pattern, by pulling the `Js` variant of the enum out of `foreign_links` and into the regular list, and writing a `From` implementation by hand. This seems like a bad idea per the new docs, but I'm not sure how the overall shape of the library would have to change in order not to do it; `?` is used on Neon results extensively throughout the library.

refs #21 