### PR TITLE
Support compiling on 32-bit Systems as well

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -172,9 +172,19 @@ where
         Ok(js_str.upcast())
     }
 
+    #[cfg(target_pointer_width = "64")]
     #[inline]
     fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
         let mut buff = JsBuffer::new(self.cx, cast::u32(v.len())?)?;
+        self.cx.borrow_mut(&mut buff, |buff| buff.as_mut_slice().clone_from_slice(v));
+        Ok(buff.upcast())
+    }
+
+
+    #[cfg(not(target_pointer_width = "64"))]
+    #[inline]
+    fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
+        let mut buff = JsBuffer::new(self.cx, cast::u32(v.len()))?;
         self.cx.borrow_mut(&mut buff, |buff| buff.as_mut_slice().clone_from_slice(v));
         Ok(buff.upcast())
     }


### PR DESCRIPTION
Hi,
I just added alternative version of serialize_bytes to also compile for 32 bit systems. As I need it for compiling on the raspberry pi. Currently it just stops compiling with the following error:
```
error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
   --> /home/node/.cargo/registry/src/github.com-1ecc6299db9ec823/neon-serde-0.1.1/src/ser.rs:177:47
    |
177 |         let mut buff = JsBuffer::new(self.cx, cast::u32(v.len())?)?;
    |                                               ^^^^^^^^^^^^^^^^^^^ the `?` operator cannot be applied to type `u32`
    |
    = help: the trait `std::ops::Try` is not implemented for `u32`
    = note: required by `std::ops::Try::into_result`
```

This happens because cast gives a `u32` if trying to cast a `u32` to a `u32` (As is written in their docs https://docs.rs/cast/0.2.2/cast/ ).

This should fix #28 