### PR TITLE
Cargo.toml: Bump the versions of neon and the neon-runtime.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ readme = "readme.md"
 [dependencies]
 serde = "1.*"
 error-chain = "0.12.*"
-neon = "0.3.1"
-neon-runtime = "0.3.1"
+neon = "0.4.0"
+neon-runtime = "0.4.0"
 
 [dependencies.num]
 version = "0.2"

--- a/test/native/Cargo.toml
+++ b/test/native/Cargo.toml
@@ -11,10 +11,10 @@ name = "test"
 crate-type = ["dylib"]
 
 [build-dependencies]
-neon-build = "0.3.1"
+neon-build = "0.4.0"
 
 [dependencies]
-neon = "0.3.1"
+neon = "0.4.0"
 neon-serde = { path = "../../" }
 serde_derive = "1.0.0"
 serde = "1.0.0"

--- a/test_macro/native/Cargo.toml
+++ b/test_macro/native/Cargo.toml
@@ -11,10 +11,10 @@ name = "test"
 crate-type = ["dylib"]
 
 [build-dependencies]
-neon-build = "0.3.1"
+neon-build = "0.4.0"
 
 [dependencies]
-neon = "0.3.1"
+neon = "0.4.0"
 neon-serde = { path = "../../" }
 serde_derive = "1.*"
 serde = "1.*"


### PR DESCRIPTION
This just bumps the neon version dependencies, since there's a new neon release.
Tested with a project that it works as expected. Nothing seems to be broken.

Would be nice to get a release out with the bumped dependencies.

Thanks.