### PR TITLE
Update throw_error_from_utf8 to match neon in >0.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neon-serde"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Gabriel Castro <dev@GabrielCastro.ca>"]
 description = "Easily serialize object for use with neon"
 license = "MIT"
@@ -10,8 +10,8 @@ readme = "readme.md"
 [dependencies]
 serde = "1"
 error-chain = "0.12"
-neon = "0.4"
-neon-runtime = "0.4"
+neon = "0.4.1"
+neon-runtime = "0.4.1"
 
 [dependencies.num]
 version = "0.2"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -93,7 +93,11 @@ impl From<Error> for neon::result::Throw {
         };
         let msg = format!("{:?}", err);
         unsafe {
-            neon_runtime::error::throw_error_from_utf8(msg.as_ptr(), msg.len() as i32);
+            neon_runtime::error::throw_error_from_utf8(
+                neon_runtime::call::current_isolate(),
+                msg.as_ptr(),
+                msg.len() as i32,
+            );
             neon::result::Throw
         }
     }


### PR DESCRIPTION
`neon-serde` depends on `neon-rumtime` which is considered an *internal* crate of `neon`. It's API explicitly does not conform to semver rules like the public `neon` crate.

Ideally `neon-serde` would only depend on the public API of neon. However, throwing an error requires a context which is not currently available in `neon-serde` errors. This quick fix is in lieu of more substantial changes.