### PR TITLE
Add Support for Deserializing newtype struct

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -143,6 +143,13 @@ impl<'x, 'd, 'a, 'j, C: Context<'j>> serde::de::Deserializer<'x> for &'d mut Des
         visitor.visit_byte_buf(copy)
     }
 
+    fn deserialize_newtype_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'x>,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
     fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'x>,
@@ -154,7 +161,6 @@ impl<'x, 'd, 'a, 'j, C: Context<'j>> serde::de::Deserializer<'x> for &'d mut Des
        <V: Visitor<'x>>
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
         unit unit_struct seq tuple tuple_struct map struct identifier
-        newtype_struct
     }
 }
 

--- a/test/__tests__/get_values.js
+++ b/test/__tests__/get_values.js
@@ -53,6 +53,7 @@ describe('all values ok', () => {
             p: [1, 2, 3.5],
             q: 999,
             r: 333,
+            s: 1
         });
     });
 
@@ -84,6 +85,7 @@ describe('all values ok', () => {
             p: [1, 2, 3.5],
             q: 999,
             r: 333,
+            s: 1
         };
 
         o.self = o;
@@ -130,6 +132,7 @@ describe('all values ok', () => {
             p: [1, 2, 3.5],
             q: 999,
             r: 333,
+            s: 1
         };
         const o2 = native.roundtrip_object(o);
         expect(o).toEqual(o2);

--- a/test/native/src/lib.rs
+++ b/test/native/src/lib.rs
@@ -20,6 +20,9 @@ struct Inner;
 struct Inner2(i32, bool, String);
 
 #[derive(Serialize, Debug, Deserialize, Eq, PartialEq)]
+struct Inner3(u8);
+
+#[derive(Serialize, Debug, Deserialize, Eq, PartialEq)]
 enum TypeEnum {
     Empty,
     Tuple(u32, String),
@@ -46,6 +49,7 @@ struct AnObjectTwo {
     p: Vec<f64>,
     q: u128,
     r: i128,
+    s: Inner3
 }
 
 macro_rules! make_test {
@@ -106,6 +110,7 @@ make_test!(make_object, {
         p: vec![1., 2., 3.5],
         q: 999,
         r: 333,
+        s: Inner3(1)
     };
     value
 });
@@ -154,7 +159,8 @@ make_expect!(
         o: TypeEnum::Value(vec!['z', 'y', 'x']),
         p: vec![1., 2., 3.5],
         q: 999,
-        r: 333
+        r: 333,
+        s: Inner3(1)
     },
     AnObjectTwo
 );


### PR DESCRIPTION
This resolves an issue I discovered where deserializing a newtype struct throws an error.

Given:
```
...

#[derive(Serialize, Deserialize)]
struct Id(u8);

export! {
    fn deserialize_id(id: Id) -> Id {
        id
    }
}
```

Calling the function throws this error:

```
Error: Error(Msg("invalid type: integer `1`, expected tuple struct Id"), State { next_error: None, backtrace: InternalBacktrace { backtrace: None } })
```

This change here resolves that error by adding a function to explicitly deserialize the newtype struct instead of passing to deserialize_any. I'm open feedback on whether this is the correct approach or if this can be improved on.